### PR TITLE
Added script to automatically download plugin binaries

### DIFF
--- a/src/snap/Dockerfile
+++ b/src/snap/Dockerfile
@@ -17,7 +17,7 @@
 FROM ubuntu:16.04
 MAINTAINER Maria Rolbiecka maria.a.rolbiecka@intel.com
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl wget
 
 ENV SNAP_VERSION 1.0.0
 ENV SNAP_DOWNLOAD_URL https://github.com/intelsdi-x/snap/releases/download/${SNAP_VERSION}/snap-${SNAP_VERSION}-linux-amd64.tar.gz
@@ -45,4 +45,5 @@ RUN mkdir /var/log/autoload
 EXPOSE 8181 8777
 
 COPY snapteld.conf /etc/snap/snapteld.conf
-CMD /usr/local/sbin/snapteld 
+COPY start.sh /
+ENTRYPOINT ["/start.sh"]

--- a/src/snap/start.sh
+++ b/src/snap/start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# If there is file with plugin URLs, download those plugins to autoload directory.
+if [ -f /etc/snap/plugins.yaml ]
+  then
+    echo "-----------------------Downloading plugins-----------------------"
+    while read plugin_address; do
+      plugin=`echo $plugin_address | rev | cut -d / -f 1 | rev`
+      if [ "$plugin" == "" ]
+        then
+          continue
+      fi
+      echo "wget $plugin_address -O /opt/snap/autoload/$plugin"
+      wget $plugin_address -O /opt/snap/autoload/$plugin
+    done </etc/snap/plugins.yaml 
+    chmod -R +x /opt/snap/autoload
+fi
+
+echo "-----------------------Starting Snap-----------------------"
+snapteld -t 0


### PR DESCRIPTION
Added functionality of automatically downloading and loading Snap plugins:
Changes in code:
- start.sh downloads plugins specified in /etc/snap/plugins.yaml file and starts Snap daemon.