### PR TITLE
Snap Docker image with preloaded plugins

### DIFF
--- a/src/helm/Dockerfile
+++ b/src/helm/Dockerfile
@@ -1,0 +1,57 @@
+#
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+# Copyright 2017 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ubuntu:16.04
+MAINTAINER Maria Rolbiecka maria.a.rolbiecka@intel.com
+
+RUN apt-get update && apt-get install -y curl
+
+ENV SNAP_VERSION 1.0.0
+ENV SNAP_DOWNLOAD_URL https://github.com/intelsdi-x/snap/releases/download/${SNAP_VERSION}/snap-${SNAP_VERSION}-linux-amd64.tar.gz
+ENV SNAP_DIR /snap
+
+WORKDIR ${SNAP_DIR}
+
+RUN curl -sfL "$SNAP_DOWNLOAD_URL" -o snap-telemetry.tar.gz \
+    && tar xf snap-telemetry.tar.gz \
+    && rm snap-telemetry.tar.gz \
+    && cp snapteld /usr/local/sbin \
+    && cp snaptel /usr/local/bin
+
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 1.12.4
+ENV DOCKER_SHA256 f7cb7bb55d6ceba3ba3d24d62027e84799763b4c41b0bda5d8d5b9ba31ed0f2f 
+
+RUN curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz" -o /usr/local/bin/docker \
+	&& echo "${DOCKER_SHA256}  /usr/local/bin/docker" | sha256sum -c - \
+	&& chmod +x /usr/local/bin/docker
+
+RUN mkdir -p /var/log/snap /opt/snap/autoload /proc_host
+
+RUN cd /opt/snap/autoload \
+    && curl -fSL "https://github.com/raintank/snap-plugin-collector-snapstats/releases/download/v0.0.1/snap-plugin-collector-snapstats" -o snap-plugin-collector-snapstats \
+    && curl -fSL "https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/releases/download/21/snap-plugin-publisher-influxdb_linux_x86_64" -o snap-plugin-publisher-influxdb \
+    && curl -fSL "https://github.com/raintank/snap-plugin-collector-kubestate/releases/download/1/snap-plugin-collector-kubestate_linux_x86_64" -o snap-plugin-collector-kubestate \
+    && curl -fSL "https://github.com/intelsdi-x/snap-plugin-collector-docker/releases/download/7/snap-plugin-collector-docker_linux_x86_64" -o snap-plugin-collector-docker
+
+RUN chmod -R +x /opt/snap/autoload
+
+EXPOSE 8181 8777
+
+COPY tasks/* /opt/snap/autoload/
+COPY snapteld.conf /etc/snap/snapteld.conf
+COPY start.sh /
+ENTRYPOINT ["/start.sh"]    

--- a/src/helm/snapteld.conf
+++ b/src/helm/snapteld.conf
@@ -1,0 +1,119 @@
+#
+# Copyright 2017 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+# log_level for the snap daemon. Supported values are
+# 1 - Debug, 2 - Info, 3 - Warning, 4 - Error, 5 - Fatal.
+# Default value is 3.
+log_level: 3 
+
+# log_path sets the path for logs for the snap daemon. By
+# default snapteld prints all logs to stdout. Any provided
+# path will send snapteld logs to a file called snapteld.log in
+# the provided directory.
+# log_path: /snap
+
+# Gomaxprocs sets the number of cores to use on the system
+# for snapteld to use. Default for gomaxprocs is 1
+# gomaxprocs: 1
+
+# Control sections for configuration settings for the plugin
+# control module of snapteld.
+control:
+  # auto_discover_path sets a directory to auto load plugins on the start
+  # of the snap daemon
+  auto_discover_path: /opt/snap/autoload
+
+  # cache_expiration sets the time interval for the plugin cache to use before
+  # expiring collection results from collect plugins. Default value is 500ms
+  # cache_expiration: 500ms
+
+  # max_running_plugins sets the size of the available plugin pool for each
+  # plugin loaded in the system. Default value is 3
+  # max_running_plugins: 3
+
+  # keyring_paths sets the directory(s) to search for keyring files for signed
+  # plugins. This can be a comma separated list of directories
+  # keyring_paths: /etc/snap/keyrings
+
+  # plugin_trust_level sets the plugin trust level for snapteld. The default state
+  # for plugin trust level is enabled (1). When enabled, only signed plugins that can
+  # be verified will be loaded into snapteld. Signatures are verifed from
+  # keyring files specided in keyring_path. Plugin trust can be disabled (0) which
+  # will allow loading of all plugins whether signed or not. The warning state allows
+  # for loading of signed and unsigned plugins. Warning messages will be displayed if
+  # an unsigned plugin is loaded. Any signed plugins that can not be verified will
+  # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
+  plugin_trust_level: 0
+
+  # plugins section contains plugin config settings that will be applied for
+  # plugins across tasks.
+  # plugins:
+
+# scheduler configuration settings contains all settings for scheduler
+# module
+# scheduler:
+  # work_manager_queue_size sets the size of the worker queue inside snapteld scheduler.
+  # Default value is 25.
+  # work_manager_queue_size: 25
+
+  # work_manager_pool_size sets the size of the worker pool inside snapteld scheduler.
+  # Default value is 4.
+  # work_manager_pool_size: 4
+
+# rest sections contains all the configuration items for the REST API server.
+# restapi:
+  # enable controls enabling or disabling the REST API for snapteld. Default value is enabled.
+  # enable: true
+
+  # https enables HTTPS for the REST API. If no default certificate and key are provided, then
+  # the REST API will generate a private and public key to use for communication. Default
+  # value is false
+  # https: false
+
+  # rest_auth enables authentication for the REST API. Default value is false
+  # rest_auth: false
+
+  # rest_auth_password sets the password to use for the REST API. Currently user and password
+  # combinations are not supported.
+  # rest_auth_password: changeme
+
+  # rest_certificate is the path to the certificate to use for REST API when HTTPS is also enabled.
+  # rest_certificate: /etc/snap/cert.pem
+
+  # rest_key is the path to the private key for the certificate in use by the REST API
+  # when HTTPs is enabled.
+  # rest_key: /etc/snap/cert.key
+
+  # port sets the port to start the REST API server on. Default is 8181
+  # port: 8181
+
+# tribe section contains all configuration items for the tribe module
+# tribe:
+  # enable controls enabling tribe for the snapteld instance. Default value is false.
+  # enable: false
+
+  # bind_addr sets the IP address for tribe to bind.
+  # bind_addr: 127.0.0.1
+
+  # bind_port sets the port for tribe to listen on. Default value is 6000
+  # bind_port: 6000
+
+  # name sets the name to use for this snapteld instance in the tribe
+  # membership. Default value defaults to local hostname of the system.
+  # name: localhost
+
+  # seed sets the snapteld instance to use as the seed for tribe communications
+  # seed: localhost:6000

--- a/src/helm/start.sh
+++ b/src/helm/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+# Copyright 2017 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ -z "$INFLUXDB_USER" ]]; then
+    export INFLUXDB_USER=admin
+fi
+if [[ -z "$INFLUXDB_PASS" ]]; then
+    export INFLUXDB_PASS=admin
+fi
+sed -i "s/user.*/user: $INFLUXDB_USER/" /opt/snap/autoload/kubestate.yml
+sed -i "s/password.*/password: $INFLUXDB_PASS/" /opt/snap/autoload/kubestate.yml
+sed -i "s/user.*/user: $INFLUXDB_USER/" /opt/snap/autoload/docker.yml
+sed -i "s/password.*/password: $INFLUXDB_PASS/" /opt/snap/autoload/docker.yml
+sed -i "s/user.*/user: $INFLUXDB_USER/" /opt/snap/autoload/snapstats.yml
+sed -i "s/password.*/password: $INFLUXDB_PASS/" /opt/snap/autoload/snapstats.yml
+
+snapteld 

--- a/src/helm/tasks/docker.yml
+++ b/src/helm/tasks/docker.yml
@@ -1,0 +1,29 @@
+---
+  version: 1
+  name: docker
+  schedule:
+    type: "simple"
+    interval: "10s"
+    deadline: "10s"
+  max-failures: -1
+  workflow:
+    collect:
+      metrics:
+        /intel/docker/*/stats/cgroups/cpu_stats/*: {}
+        /intel/docker/*/stats/cgroups/memory_stats/*: {}
+        /intel/docker/*/stats/filesystem/*: {}
+      config:
+        /intel/docker:
+          procfs: "/proc_host"
+      publish:
+      - plugin_name: "influxdb"
+        config:
+          host: "monitoring-influxdb"
+          port: 8086
+          database: "snap"
+          user: admin 
+          password: admin
+          scheme: http
+          skip-verify: true
+          isMultiFields: false 
+

--- a/src/helm/tasks/kubestate.yml
+++ b/src/helm/tasks/kubestate.yml
@@ -1,0 +1,27 @@
+---
+  version: 1
+  name: kubestate
+  schedule:
+    type: "simple"
+    interval: "10s"
+    deadline: "10s"
+  max-failures: -1
+  workflow:
+    collect:
+      metrics:
+        /grafanalabs/kubestate/pod/*/*/*/status/*: {}
+        /grafanalabs/kubestate/node/*/: {}
+      config:
+        /grafanalabs/kubestate:
+          incluster: true
+      publish:
+      - plugin_name: "influxdb"
+        config:
+          host: "monitoring-influxdb"
+          port: 8086
+          database: "snap"
+          user: admin 
+          password: admin
+          scheme: http
+          skip-verify: true
+          isMultiFields: false 

--- a/src/helm/tasks/snapstats.yml
+++ b/src/helm/tasks/snapstats.yml
@@ -1,0 +1,26 @@
+---
+  version: 1
+  name: snapstats
+  schedule:
+    type: "simple"
+    interval: "5s"
+    deadline: "5s"
+  max-failures: -1
+  workflow:
+    collect:
+      metrics:
+        /grafanalabs/snapstats/*: {}
+      config:
+        /grafanalabs/snapstats:
+          snap-url: "http://localhost:8181"
+      publish:
+      - plugin_name: "influxdb"
+        config:
+          host: "monitoring-influxdb" 
+          port: 8086
+          database: "snap"
+          user: admin
+          password: admin
+          scheme: http
+          skip-verify: true
+          isMultiFields: false


### PR DESCRIPTION
Docker image with plugins and tasks to monitor Kubernetes. No tribe used.
Plugins used in this image:
- InfluxDB publisher,
- CPU collector,
- Docker collector,
- Kubestate collector,
- Snapstats collector,
- Meminfo collector

Tested manually.
