### PR TITLE
Helm chart for Kubernetes monitoring using Snap

### DIFF
--- a/run/helm/snap/.helmignore
+++ b/run/helm/snap/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/run/helm/snap/Chart.yaml
+++ b/run/helm/snap/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+description: Snap monitoring stack for Kubernetes
+keywords:
+  - monitoring
+  - telemetry
+  - metrics
+name: snap
+version: 1.1.0
+sources:
+  - https://github.com/intelsdi-x/snap
+maintainers:
+  - name: Maria Rolbiecka
+    email: maria.a.rolbiecka@intel.com
+  - name: Andrzej Kuriata
+    email: andrzej.kuriata@intel.com
+icon: https://cloud.githubusercontent.com/assets/1744971/20331694/e07e9148-ab5b-11e6-856a-e4e956540077.png

--- a/run/helm/snap/charts/grafana/Chart.yaml
+++ b/run/helm/snap/charts/grafana/Chart.yaml
@@ -1,0 +1,10 @@
+description: A Helm chart for Kubernetes
+engine: gotpl
+home: https://grafana.net
+maintainers:
+- email: zanhsieh@gmail.com
+  name: Ming Hsieh
+name: grafana
+sources:
+- https://github.com/grafana/grafana
+version: 0.2.1

--- a/run/helm/snap/charts/grafana/templates/NOTES.txt
+++ b/run/helm/snap/charts/grafana/templates/NOTES.txt
@@ -1,0 +1,38 @@
+1. Get your '{{ .Values.server.adminUser }}' user password by running:
+
+   printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode);echo
+
+2. The Grafana server can be accessed via port {{ .Values.server.httpPort }} on the following DNS name from within your cluster:
+
+   {{ template "server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ if .Values.server.ingress.enabled }}
+   From outside the cluster, the server URL(s) are:
+{{- range .Values.server.ingress.hosts }}
+     http://{{ . }}
+{{- end }}
+{{ else }}
+   Get the Grafana URL to visit by running these commands in the same shell:
+{{ if contains "NodePort" .Values.server.serviceType -}}
+     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "server.fullname" . }})
+     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+     echo http://$NODE_IP:$NODE_PORT
+{{ else if contains "LoadBalancer" .Values.server.serviceType -}}
+   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "server.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+     echo http://$SERVICE_IP:{{ .Values.server.httpPort -}}
+{{ else if contains "ClusterIP"  .Values.server.serviceType }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},component={{ .Values.server.name }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000
+{{- end }}
+{{- end }}
+
+3. Login with the password from step 1 and the username: {{ .Values.server.adminUser }}
+
+{{- if .Values.server.persistentVolume.enabled }}
+{{- else }}
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Grafana pod is terminated.                            #####
+#################################################################################
+{{- end }}

--- a/run/helm/snap/charts/grafana/templates/_helpers.tpl
+++ b/run/helm/snap/charts/grafana/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default "grafana" .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified server name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "server.fullname" -}}
+{{- printf "%s-%s" .Release.Name "grafana" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "template" -}}
+{{- $name := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $v:= $context.Template.Name | split "/" -}}
+{{- $n := len $v -}}
+{{- $last := sub $n 1 | printf "_%d" | index $v -}}
+{{- $path := $context.Template.Name | replace $last $name -}}
+{{ include $path $context }}
+{{- end -}}

--- a/run/helm/snap/charts/grafana/templates/config.yaml
+++ b/run/helm/snap/charts/grafana/templates/config.yaml
@@ -1,0 +1,158 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}-config
+data:
+  grafana.ini: |
+    ; app_mode = production
+    ; instance_name = ${HOSTNAME}
+    [paths]
+    data = /var/lib/grafana/data
+    logs = /var/log/grafana
+    plugins = /var/lib/grafana/plugins
+
+    [server]
+    ;protocol = http
+    ;http_addr =
+    ;http_port = 3000
+    ;domain = localhost
+    ;enforce_domain = false
+    ;root_url = %(protocol)s://%(domain)s:%(http_port)s/
+    ;router_logging = false
+    ;static_root_path = public
+    ;enable_gzip = false
+    ;cert_file =
+    ;cert_key =
+
+    [database]
+    ;type = sqlite3
+    ;host = 127.0.0.1:3306
+    ;name = grafana
+    ;user = root
+    ;password =
+    ;ssl_mode = disable
+    ;path = grafana.db
+
+    [session]
+    ;provider = file
+    ;provider_config = sessions
+    ;cookie_name = grafana_sess
+    ;cookie_secure = false
+    ;session_life_time = 86400
+
+    [analytics]
+    reporting_enabled = false
+    check_for_updates = false
+    ;google_analytics_ua_id =
+
+    [security]
+    ;admin_user = admin
+    ;admin_password = admin
+    ;secret_key = SW2YcwTIb9zpOOhoPsMm
+    ;login_remember_days = 7
+    ;cookie_username = grafana_user
+    ;cookie_remember_name = grafana_remember
+    ;disable_gravatar = false
+    ;data_source_proxy_whitelist =
+
+    [snapshots]
+    external_enabled = false
+    ;external_snapshot_url = https://snapshots-origin.raintank.io
+    ;external_snapshot_name = Publish to snapshot.raintank.io
+
+    [users]
+    allow_sign_up = false
+    allow_org_create = false
+    ;auto_assign_org = true
+    ;auto_assign_org_role = Viewer
+    ;login_hint = email or username
+    ;default_theme = dark
+
+    [auth.anonymous]
+    ;enabled = false
+    ;org_name = Main Org.
+    ;org_role = Viewer
+
+    [auth.github]
+    ;enabled = true
+    ;allow_sign_up = false
+    ;client_id = 
+    ;client_secret = 
+    ;scopes = user:email,read:org
+    ;auth_url = https://github.com/login/oauth/authorize
+    ;token_url = https://github.com/login/oauth/access_token
+    ;api_url = https://api.github.com/user
+    ;team_ids = kopernik-admins,kopernik-devs
+    ;allowed_organizations = intelsdi-x
+
+    [auth.google]
+    ;enabled = false
+    ;allow_sign_up = false
+    ;client_id = some_client_id
+    ;client_secret = some_client_secret
+    ;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+    ;auth_url = https://accounts.google.com/o/oauth2/auth
+    ;token_url = https://accounts.google.com/o/oauth2/token
+    ;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+    ;allowed_domains =
+
+    [auth.proxy]
+    ;enabled = false
+    ;header_name = X-WEBAUTH-USER
+    ;header_property = username
+    ;auto_sign_up = true
+
+    [auth.basic]
+    ;enabled = true
+
+    [auth.ldap]
+    ;enabled = false
+    ;config_file = /etc/grafana/ldap.toml
+
+    [smtp]
+    ;enabled = false
+    ;host = localhost:25
+    ;user =
+    ;password =
+    ;cert_file =
+    ;key_file =
+    ;skip_verify = false
+    ;from_address = admin@grafana.localhost
+
+    [emails]
+    ;welcome_email_on_sign_up = false
+
+    [log]
+    mode = console
+    level = info
+
+    [log.console]
+    ;level =
+    ;format = console
+
+    [event_publisher]
+    ;enabled = false
+    ;rabbitmq_url = amqp://localhost/
+    ;exchange = grafana_events
+
+    [dashboards.json]
+    enabled = false
+    ;path = /var/lib/grafana/dashboards/..data/
+
+    [metrics]
+    ;enabled           = true
+    ;interval_seconds  = 10
+
+    ; [metrics.graphite]
+    ; address = localhost:2003
+    ; prefix = prod.grafana.%(instance_name)s.
+
+    [grafana_net]
+    url = https://grafana.net
+

--- a/run/helm/snap/charts/grafana/templates/dashboards/_cluster.json.tpl
+++ b/run/helm/snap/charts/grafana/templates/dashboards/_cluster.json.tpl
@@ -1,0 +1,1019 @@
+{
+	"dashboard": {
+		"__inputs": [{
+			"name": "snap",
+			"label": "snap",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "influxdb",
+			"pluginName": "InfluxDB"
+		}],
+		"__requires": [{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "4.2.0-beta1"
+		}, {
+			"type": "panel",
+			"id": "graph",
+			"name": "Graph",
+			"version": ""
+		}, {
+			"type": "datasource",
+			"id": "influxdb",
+			"name": "InfluxDB",
+			"version": "1.0.0"
+		}],
+		"annotations": {
+			"list": []
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"hideControls": false,
+		"id": null,
+		"links": [],
+		"refresh": "1m",
+		"rows": [{
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+							    {{ .Values.server.alerting.nodes.cpu_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"B",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"name": "CPU Usage by Node alert",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 2,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $tag_node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1s"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"measurement": "intel/docker/stats/cgroups/cpu_stats/cpu_usage/per_cpu/value",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}, {
+							"params": [
+								"1s"
+							],
+							"type": "derivative"
+						}, {
+							"params": [
+								" / 10000000"
+							],
+							"type": "math"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}, {
+					"alias": "",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1s"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"hide": true,
+					"measurement": "intel/docker/stats/cgroups/cpu_stats/cpu_usage/per_cpu/value",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}, {
+							"params": [
+								"1s"
+							],
+							"type": "derivative"
+						}, {
+							"params": [
+								" / 10000000"
+							],
+							"type": "math"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 90
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "CPU Usage by Node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "percent",
+					"label": null,
+					"logBase": 1,
+					"max": "100",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapsy": false,
+			"height": 250,
+			"panels": [{
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 3,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1s"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"measurement": "intel/docker/stats/cgroups/cpu_stats/cpu_usage/per_cpu/value",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}, {
+							"params": [
+								"1s"
+							],
+							"type": "derivative"
+						}, {
+							"params": [
+								" / 10000000"
+							],
+							"type": "math"
+						}]
+					],
+					"tags": [{
+						"key": "node",
+						"operator": "=~",
+						"value": "/^$node$/"
+					}, {
+						"condition": "AND",
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Individual CPU Usage: $node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "percent",
+					"label": null,
+					"logBase": 1,
+					"max": "100",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+                                                            {{ .Values.server.alerting.nodes.memory_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"B",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"message": "HI!!!",
+					"name": "Memory Usage by Node alert",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 6,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $tag_node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1m"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"measurement": "intel/docker/stats/cgroups/memory_stats/usage/usage",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}, {
+					"alias": "",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1m"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"hide": true,
+					"measurement": "intel/docker/stats/cgroups/memory_stats/usage/usage",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 54532577904
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Memory Usage by Node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": "70000000000",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 5,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1m"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"measurement": "intel/docker/stats/cgroups/memory_stats/usage/usage",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}]
+					],
+					"tags": [{
+						"key": "node",
+						"operator": "=~",
+						"value": "/^$node$/"
+					}, {
+						"condition": "AND",
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Individual Memory Usage: $node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": "70000000000",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+							    {{ .Values.server.alerting.nodes.filesystem_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"C",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"name": "Filesystem Usage by Node alert",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 12,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $tag_node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}],
+					"measurement": "intel/docker/stats/filesystem/usage",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}, {
+					"alias": "Limit $tag_node",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}],
+					"measurement": "intel/docker/stats/filesystem/available",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}, {
+					"alias": "",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"node"
+						],
+						"type": "tag"
+					}],
+					"hide": true,
+					"measurement": "intel/docker/stats/filesystem/usage",
+					"policy": "default",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 500000000000
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Filesystem Usage by Node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 13,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $node",
+					"dsType": "influxdb",
+					"groupBy": [],
+					"measurement": "intel/docker/stats/filesystem/usage",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "node",
+						"operator": "=~",
+						"value": "/^$node$/"
+					}, {
+						"condition": "AND",
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}, {
+					"alias": "Limit $node",
+					"dsType": "influxdb",
+					"groupBy": [],
+					"measurement": "intel/docker/stats/filesystem/available",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "node",
+						"operator": "=~",
+						"value": "/^$node$/"
+					}, {
+						"condition": "AND",
+						"key": "docker_id",
+						"operator": "=",
+						"value": "root"
+					}]
+				}],
+				"thresholds": [],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Individual Filesystem Usage: $node",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}],
+		"schemaVersion": 14,
+		"style": "dark",
+		"tags": [],
+		"templating": {
+			"list": [{
+				"allValue": null,
+				"current": {},
+				"datasource": "snap",
+				"hide": 0,
+				"includeAll": false,
+				"label": null,
+				"multi": false,
+				"name": "node",
+				"options": [],
+				"query": "SHOW TAG VALUES WITH KEY = \"node\" ",
+				"refresh": 1,
+				"regex": "",
+				"sort": 0,
+				"tagValuesQuery": "",
+				"tags": [],
+				"tagsQuery": "",
+				"type": "query",
+				"useTags": false
+			}]
+		},
+		"time": {
+			"from": "now-30m",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "browser",
+		"title": "Cluster",
+		"version": 60
+	}
+}

--- a/run/helm/snap/charts/grafana/templates/dashboards/_pods.json.tpl
+++ b/run/helm/snap/charts/grafana/templates/dashboards/_pods.json.tpl
@@ -1,0 +1,680 @@
+{
+	"dashboard": {
+		"__inputs": [{
+			"name": "snap",
+			"label": "snap",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "influxdb",
+			"pluginName": "InfluxDB"
+		}],
+		"__requires": [{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "4.1.2"
+		}, {
+			"type": "panel",
+			"id": "graph",
+			"name": "Graph",
+			"version": ""
+		}, {
+			"type": "datasource",
+			"id": "influxdb",
+			"name": "InfluxDB",
+			"version": "1.0.0"
+		}],
+		"annotations": {
+			"list": []
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"hideControls": false,
+		"id": null,
+		"links": [],
+		"refresh": "5s",
+		"rows": [{
+			"collapse": false,
+			"height": "250px",
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+	                                                     {{ .Values.server.alerting.pods.cpu_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"C",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"name": "Individual CPU Usage",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 1,
+				"interval": "",
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "CPU Usage $namespace $podname",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1s"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"interval": "",
+					"measurement": "intel/docker/stats/cgroups/cpu_stats/cpu_usage/per_cpu/value",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "max"
+						}, {
+							"params": [
+								"1s"
+							],
+							"type": "derivative"
+						}, {
+							"params": [
+								" / 10000000"
+							],
+							"type": "math"
+						}]
+					],
+					"tags": [{
+						"key": "io.kubernetes.pod.name",
+						"operator": "=~",
+						"value": "/^$podname$/"
+					}, {
+						"condition": "AND",
+						"key": "io.kubernetes.pod.namespace",
+						"operator": "=~",
+						"value": "/^$namespace$/"
+					}]
+				}, {
+					"alias": "",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1s"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"io.kubernetes.pod.name"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"hide": true,
+					"interval": "",
+					"measurement": "intel/docker/stats/cgroups/cpu_stats/cpu_usage/per_cpu/value",
+					"policy": "default",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "max"
+						}, {
+							"params": [
+								"1s"
+							],
+							"type": "derivative"
+						}, {
+							"params": [
+								" / 10000000"
+							],
+							"type": "math"
+						}]
+					],
+					"tags": []
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 90
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Individual CPU Usage: $namespace $podname",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "percent",
+					"label": null,
+					"logBase": 1,
+					"max": "100",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+							    {{ .Values.server.alerting.pods.memory_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"B",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"name": "Individual Memory Usage aler",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 2,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Memory Usage $namespace $podname",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1m"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"measurement": "intel/docker/stats/cgroups/memory_stats/usage/usage",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}]
+					],
+					"tags": [{
+						"key": "io.kubernetes.pod.name",
+						"operator": "=~",
+						"value": "/^$podname$/"
+					}, {
+						"condition": "AND",
+						"key": "io.kubernetes.pod.namespace",
+						"operator": "=~",
+						"value": "/^$namespace$/"
+					}]
+				}, {
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"1m"
+						],
+						"type": "time"
+					}, {
+						"params": [
+							"io.kubernetes.pod.name"
+						],
+						"type": "tag"
+					}, {
+						"params": [
+							"null"
+						],
+						"type": "fill"
+					}],
+					"hide": true,
+					"measurement": "intel/docker/stats/cgroups/memory_stats/usage/usage",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}, {
+							"params": [],
+							"type": "mean"
+						}]
+					],
+					"tags": []
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 20000000000
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Individual Memory Usage: $namespace $podname",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": "20000000000",
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}, {
+			"collapse": false,
+			"height": 250,
+			"panels": [{
+				"alert": {
+					"conditions": [{
+						"evaluator": {
+							"params": [
+							     {{ .Values.server.alerting.pods.filesystem_usage }}
+							],
+							"type": "gt"
+						},
+						"operator": {
+							"type": "and"
+						},
+						"query": {
+							"params": [
+								"C",
+								"5m",
+								"now"
+							]
+						},
+						"reducer": {
+							"params": [],
+							"type": "avg"
+						},
+						"type": "query"
+					}],
+					"executionErrorState": "alerting",
+					"frequency": "60s",
+					"handler": 1,
+					"name": "Filesystem Usage alert",
+					"noDataState": "no_data",
+					"notifications": []
+				},
+				"aliasColors": {},
+				"bars": false,
+				"datasource": "snap",
+				"fill": 0,
+				"id": 3,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [],
+				"span": 12,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [{
+					"alias": "Usage $namespace $podname",
+					"dsType": "influxdb",
+					"groupBy": [],
+					"measurement": "intel/docker/stats/filesystem/usage",
+					"policy": "default",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "io.kubernetes.pod.name",
+						"operator": "=~",
+						"value": "/^$podname$/"
+					}, {
+						"condition": "AND",
+						"key": "io.kubernetes.pod.namespace",
+						"operator": "=~",
+						"value": "/^$namespace$/"
+					}]
+				}, {
+					"alias": "Limit $namespace $podname",
+					"dsType": "influxdb",
+					"groupBy": [],
+					"measurement": "intel/docker/stats/filesystem/available",
+					"policy": "default",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": [{
+						"key": "io.kubernetes.pod.name",
+						"operator": "=~",
+						"value": "/^$podname$/"
+					}, {
+						"condition": "AND",
+						"key": "io.kubernetes.pod.namespace",
+						"operator": "=~",
+						"value": "/^$namespace$/"
+					}]
+				}, {
+					"alias": "",
+					"dsType": "influxdb",
+					"groupBy": [{
+						"params": [
+							"io.kubernetes.pod.name"
+						],
+						"type": "tag"
+					}],
+					"hide": true,
+					"measurement": "intel/docker/stats/filesystem/usage",
+					"policy": "default",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[{
+							"params": [
+								"value"
+							],
+							"type": "field"
+						}]
+					],
+					"tags": []
+				}],
+				"thresholds": [{
+					"colorMode": "critical",
+					"fill": true,
+					"line": true,
+					"op": "gt",
+					"value": 500000000000
+				}],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Filesystem Usage: $namespace $podname",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": []
+				},
+				"yaxes": [{
+					"format": "bytes",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": "0",
+					"show": true
+				}, {
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}]
+			}],
+			"repeat": null,
+			"repeatIteration": null,
+			"repeatRowId": null,
+			"showTitle": false,
+			"title": "Dashboard Row",
+			"titleSize": "h6"
+		}],
+		"schemaVersion": 14,
+		"style": "dark",
+		"tags": [],
+		"templating": {
+			"list": [{
+				"allValue": null,
+				"current": {},
+				"datasource": "snap",
+				"hide": 0,
+				"includeAll": false,
+				"label": null,
+				"multi": false,
+				"name": "namespace",
+				"options": [],
+				"query": "SHOW TAG VALUES WITH KEY = \"io.kubernetes.pod.namespace\"",
+				"refresh": 1,
+				"regex": "",
+				"sort": 0,
+				"tagValuesQuery": "",
+				"tags": [],
+				"tagsQuery": "",
+				"type": "query",
+				"useTags": false
+			}, {
+				"allValue": null,
+				"current": {},
+				"datasource": "snap",
+				"hide": 0,
+				"includeAll": false,
+				"label": null,
+				"multi": false,
+				"name": "podname",
+				"options": [],
+				"query": "SHOW TAG VALUES WITH KEY = \"io.kubernetes.pod.name\"",
+				"refresh": 1,
+				"regex": "",
+				"sort": 0,
+				"tagValuesQuery": "",
+				"tags": [],
+				"tagsQuery": "",
+				"type": "query",
+				"useTags": false
+			}]
+		},
+		"time": {
+			"from": "now-6h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "browser",
+		"title": "Pods",
+		"version": 0
+	}
+}

--- a/run/helm/snap/charts/grafana/templates/deployment.yaml
+++ b/run/helm/snap/charts/grafana/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+      {{- range $key, $value := .Values.server.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.server.name }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - name: {{ template "name" . }}
+          image: "{{ .Values.server.image }}"
+          imagePullPolicy: {{ default "Always" .Values.server.imagePullPolicy }}
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "server.fullname" . }}
+                  key: grafana-admin-user
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "server.fullname" . }}
+                  key: grafana-admin-password
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+            - name: config-volume
+              mountPath: {{ default "/etc/grafana" .Values.server.configLocalPath | quote }}
+            - name: storage-volume
+              mountPath: {{ default "/var/lib/grafana/data" .Values.server.storageLocalPath | quote }}
+      terminationGracePeriodSeconds: {{ default 300 .Values.server.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "server.fullname" . }}-config
+        - name: storage-volume
+      {{- if .Values.server.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "server.fullname" . }}
+      {{- else }}
+          emptyDir: {}
+      {{- end -}}

--- a/run/helm/snap/charts/grafana/templates/ingress.yaml
+++ b/run/helm/snap/charts/grafana/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.server.ingress.enabled -}}
+{{- $releaseName := .Release.Name -}}
+{{- $servicePort := .Values.server.httpPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.server.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}
+spec:
+  rules:
+  {{- range .Values.server.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- if .Values.server.ingress.tls }}
+  tls:
+{{ toYaml .Values.server.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/run/helm/snap/charts/grafana/templates/job.yaml
+++ b/run/helm/snap/charts/grafana/templates/job.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.server.setDatasource.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}-set-datasource
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+        {
+            "name": "wait-for-grafana",
+            "image": "{{ .Values.server.setDatasource.initImage }}",
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/org; do echo waiting for myservice; sleep 5; done;"]
+        }
+    ]'
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: {{ template "server.fullname" . }}-set-datasource
+    image: "{{ .Values.server.setDatasource.image }}"
+    args:
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
+    - "-X"
+    - POST
+    - "-H"
+    - "Content-Type: application/json;charset=UTF-8"
+    - "--data-binary"
+    {{- with .Values.server.setDatasource.datasource }}
+    - |
+      {"name":"{{ .name }}",
+        "type":"{{ .type }}",
+        "url":"{{ .url }}",
+        "access":"{{ .access }}",
+        "isDefault":{{ .isDefault }},
+        {{- if contains "influxdb" .type }}
+        "password":"{{ .influxdb.password }}",
+        "user":"{{ .influxdb.user }}",
+        "database":"{{ .influxdb.database }}"
+        {{- end }}
+        }
+      {{- end }}
+  {{- end -}}

--- a/run/helm/snap/charts/grafana/templates/job_cluster.yaml
+++ b/run/helm/snap/charts/grafana/templates/job_cluster.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}-import-dash-cluster
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+        {
+            "name": "wait-for-db",
+            "image": "{{ .Values.server.setDatasource.initImage }}",
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
+        }
+    ]'
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: {{ template "server.fullname" . }}-import-dash-cluster
+    image: "{{ .Values.server.setDatasource.image }}"
+    args:
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
+    - "-X"
+    - POST
+    - "-H"
+    - "Content-Type: application/json;charset=UTF-8"
+    - "--data-binary"
+    - |
+{{ tuple "dashboards/_cluster.json.tpl" . | include "template" | indent 6 }}
+

--- a/run/helm/snap/charts/grafana/templates/job_pods.yaml
+++ b/run/helm/snap/charts/grafana/templates/job_pods.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}-import-dash-pods
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+        {
+            "name": "wait-for-db",
+            "image": "{{ .Values.server.setDatasource.initImage }}",
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
+        }
+    ]'
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: {{ template "server.fullname" . }}-import-dash-pods
+    image: "{{ .Values.server.setDatasource.image }}"
+    args:
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
+    - "-X"
+    - POST
+    - "-H"
+    - "Content-Type: application/json;charset=UTF-8"
+    - "--data-binary"
+    - |
+{{ tuple "dashboards/_pods.json.tpl" . | include "template" | indent 6 }}
+

--- a/run/helm/snap/charts/grafana/templates/pvc.yaml
+++ b/run/helm/snap/charts/grafana/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.server.persistentVolume.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+  {{- if .Values.server.persistentVolume.storageClass -}}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass | quote }}
+  {{ else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+  {{- range $key, $value := .Values.server.persistentVolume.annotations }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}
+spec:
+  accessModes:
+{{- range .Values.server.persistentVolume.accessModes }}
+    - {{ . | quote }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.server.persistentVolume.size | quote }}
+{{- end -}}

--- a/run/helm/snap/charts/grafana/templates/secret.yaml
+++ b/run/helm/snap/charts/grafana/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}
+data:
+  {{ if .Values.server.adminPassword }}
+  grafana-admin-password:  {{ .Values.server.adminPassword | b64enc | quote }}
+  {{ else }}
+  grafana-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  grafana-admin-user: {{ .Values.server.adminUser | b64enc | quote }}

--- a/run/helm/snap/charts/grafana/templates/svc.yaml
+++ b/run/helm/snap/charts/grafana/templates/svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "server.fullname" . }}
+spec:
+  ports:
+    - name: {{ default "http" .Values.server.httpPortName | quote }}
+      port: {{ .Values.server.httpPort }}
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.server.name }}"
+  type: "{{ .Values.server.serviceType }}"
+{{- if contains "LoadBalancer" .Values.server.serviceType }}
+  {{- if .Values.server.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.server.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.server.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+  {{- range .Values.server.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/run/helm/snap/charts/grafana/values.yaml
+++ b/run/helm/snap/charts/grafana/values.yaml
@@ -1,0 +1,187 @@
+server:
+  ## Grafana Pod annotations:
+  ##
+  # annotations:
+  #   iam.amazonaws.com/role: grafana
+
+  ## Grafana service port
+  ##
+  httpPort: 80
+
+  ## Grafana Docker image
+  ##
+  image: "grafana/grafana:latest"
+
+  ingress:
+    ## If true, Grafana Ingress will be created
+    ##
+    enabled: false
+
+    ## Grafana Ingress annotations
+    ##
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: 'true'
+
+    ## Grafana Ingress hostnames
+    ## Must be provided if Ingress is enabled
+    ##
+    # hosts:
+    #   - grafana.domain.com
+
+    ## Grafana Ingress TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    # tls:
+    #   - secretName: grafana-server-tls
+    #     hosts:
+    #       - grafana.domain.com
+
+  ## Grafana container name
+  ##
+  name: grafana
+
+  adminUser: "admin"
+  # adminPassword: "admin"
+
+  ## Global imagePullPolicy
+  ## Default: 'Always' if image tag is 'latest', else 'IfNotPresent'
+  ## Ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  # imagePullPolicy:
+
+  # Persist data to a persitent volume
+  persistentVolume:
+    ## If true, Grafana will create a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## Grafana data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## Server data Persistent Volume annotations
+    ##
+    # annotations:
+
+    ## Grafana data Persistent Volume size
+    ## Default: 1Gi
+    ##
+    size: 1Gi
+
+    ## Data Persistent Volume Storage Class
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+
+  ## Grafana resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+   #  limits:
+   #   cpu: 500m
+   #   memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
+  ## Grafana service type
+  ##
+  serviceType: ClusterIP
+
+  ## Load balancer IP address
+  ## Is not required, but allows for static address with
+  ## serviceType LoadBalancer.
+  ## If not supported by cloud provider, this field is ignored.
+  ## Default: nil
+  ##
+  # loadBalancerIP:
+
+  ## This will restrict traffic through the cloud-provider load-balancer
+  ## to the specified client IPs.
+  ## If not supported by cloud provider, this field is ignored.
+  ## Default: nil
+  ##
+  # loadBalancerSourceRanges:
+
+
+  ## Grafana local config path
+  ## Default '/etc/grafana'
+  ##
+  # configLocalPath: /etc/grafana
+
+  ## Grafana local dashboards path
+  ## Default: '/var/lib/grafana/dashboards'
+  ##
+  # dashboardLocalPath: /var/lib/grafana/dashboards
+
+  ## Grafana local data storage path
+  ## Default: '/var/lib/grafana/data'
+  ##
+  # storageLocalPath: /var/lib/grafana/data
+
+  ## Grafana Pod termination grace period
+  ## Default: 300s (5m)
+  ##
+  # terminationGracePeriodSeconds: 300
+
+  # Set datasource in beginning
+  setDatasource:
+    ## If true, an initial Grafana Datasource will be set
+    ## Default: false
+    ##
+    enabled: false
+
+    ## How long should it take to commit failure
+    ## Default: 300
+    ##
+    # activeDeadlineSeconds: 300
+
+    ## Curl Docker image
+    ## Default: appropriate/curl:latest
+    ##
+    initImage: cosmintitei/bash-curl
+    image: appropriate/curl:latest
+
+    ## This assembles how curl post into Grafana
+    ## Ref1: http://docs.grafana.org/reference/http_api/#create-data-source
+    ## Ref2: https://github.com/grafana/grafana/issues/1789
+    ##
+    # datasource:
+      ## The datasource name.
+      ## Default: default
+      # name: default
+
+      ## Type of datasource
+      ## Default: prometheus
+      ##
+      # type: prometheus
+
+      ## The url of the datasource. To set correctly you need to know
+      ## the right datasource name and its port ahead. Check kubernetes
+      ## dashboard or describe the service should fulfill the requirements.
+      ## Synatx like `http://<release name>-<server name>:<port number>
+      ## Default: "http://limping-tiger-server"
+      ##
+      # url: "http://limping-tiger-server"
+
+      ## Specify if Grafana has to go thru proxy to reach datasource
+      ## Default: proxy
+      ##
+      # access: proxy
+
+      ## Specify should Grafana use this datasource as default
+      ## Default: true
+      ##
+      # isDefault: true
+
+    ## Specify the job policy
+    ## Default: OnFailure
+    ##
+    # restartPolicy: OnFailure
+

--- a/run/helm/snap/charts/influxdb/Chart.yaml
+++ b/run/helm/snap/charts/influxdb/Chart.yaml
@@ -1,0 +1,5 @@
+name: influxdb
+version: 0.1.0
+description: Kubernetes deployment for InfluxDB
+keywords:
+- influxdb

--- a/run/helm/snap/charts/influxdb/templates/_helpers.tpl
+++ b/run/helm/snap/charts/influxdb/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/run/helm/snap/charts/influxdb/templates/config.yaml
+++ b/run/helm/snap/charts/influxdb/templates/config.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: influxdb-config
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+  influxdb.conf: |+
+    reporting-disabled = true
+    bind-address = ":8088"
+    [meta]
+      dir = "/var/lib/influxdb/meta"
+      retention-autocreate = true
+      logging-enabled = true
+    [data]
+      dir = "/var/lib/influxdb/data"
+      wal-dir = "/var/lib/influxdb/wal"
+    [admin]
+      enabled = false
+    [subscriber]
+      enabled = true
+      http-timeout = "30s"
+      insecure-skip-verify = false
+      ca-certs = ""
+      write-concurrency = 40
+      write-buffer-size = 1000
+    [http]
+      enabled = true
+      bind-address = ":8086"
+      auth-enabled = true

--- a/run/helm/snap/charts/influxdb/templates/deployment.yaml
+++ b/run/helm/snap/charts/influxdb/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        heritage: {{ .Release.Service | quote }}
+    spec:
+      containers:
+      - name: influxdb
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: api
+          containerPort: {{ .Values.port_number }}
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: api
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: api
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: influxdb-data
+          mountPath: /var/lib/influxdb
+        - name: influxdb-config
+          mountPath: /etc/influxdb
+      volumes:
+      - name: influxdb-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-pvc
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: influxdb-config
+        configMap:
+          name: influxdb-config

--- a/run/helm/snap/charts/influxdb/templates/post-deploy.yaml
+++ b/run/helm/snap/charts/influxdb/templates/post-deploy.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.setDefaultUser.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ template "fullname" . }}-create-user-{{ randAlphaNum 5 | lower }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  activeDeadlineSeconds: {{ default 300 .Values.setDefaultUser.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}-create-user
+        image: {{ .Values.setDefaultUser.image | quote }}
+        env:
+          - name: INFLUXDB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}-auth
+                key: influxdb-user
+          - name: INFLUXDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}-auth
+                key: influxdb-password
+        args:
+          - "/bin/sh"
+          - "-c"
+          - |
+             curl -X POST http://monitoring-influxdb:8086/query \
+             --data-urlencode \
+             "q=CREATE USER \"${INFLUXDB_USER}\" WITH PASSWORD '${INFLUXDB_PASSWORD}' {{ .Values.setDefaultUser.user.privileges }}"
+      restartPolicy: {{ .Values.setDefaultUser.restartPolicy }}
+{{- end -}}

--- a/run/helm/snap/charts/influxdb/templates/pvc.yaml
+++ b/run/helm/snap/charts/influxdb/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-pvc
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/run/helm/snap/charts/influxdb/templates/secret.yaml
+++ b/run/helm/snap/charts/influxdb/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.setDefaultUser.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  name: {{ template "fullname" . }}-auth
+data:
+  {{- if .Values.setDefaultUser.user.password }}
+  influxdb-password:  {{ .Values.setDefaultUser.user.password | b64enc | quote }}
+  {{- else }}
+  influxdb-password: {{ randAscii 10 | b64enc | quote }}
+  {{- end }}
+  influxdb-user: {{ .Values.setDefaultUser.user.username | b64enc | quote }}
+{{- end -}}

--- a/run/helm/snap/charts/influxdb/templates/service.yaml
+++ b/run/helm/snap/charts/influxdb/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-influxdb
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  ports:
+  - name: api
+    port: {{ .Values.port_number }}
+    targetPort: {{ .Values.port_number }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/run/helm/snap/charts/influxdb/values.yaml
+++ b/run/helm/snap/charts/influxdb/values.yaml
@@ -1,0 +1,63 @@
+## influxdb image version
+## ref: https://hub.docker.com/r/library/influxdb/tags/
+image:
+  repo: "influxdb"
+  tag: "1.2.0"
+  pullPolicy: IfNotPresent
+
+## Port number for influxDB queries and commands
+##
+port_number: 8086
+
+## Persist data to a persitent volume
+##
+persistence:
+  enabled: false
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    # size: 8Gi
+
+## Create default user through Kubernetes job
+## Defaults indicated below
+##
+setDefaultUser:
+  enabled: true
+
+  ## Image of the container used for job
+  ## Default: appropriate/curl:latest
+  ##
+  image: appropriate/curl:latest
+
+  ## Deadline for job so it does not retry forever.
+  ## Default: activeDeadline: 300
+  ##
+  activeDeadline: 300
+
+  ## Restart policy for job
+  ## Default: OnFailure
+  restartPolicy: OnFailure
+
+  user:
+    ## The user name
+    ## Default: "admin"
+    username: "root"
+
+    ## User password
+    ## Default: Randomly generated 10 characters of Ascii
+    password: "root"
+
+    ## User privileges
+    ## Default: "WITH ALL PRIVILEGES"
+    privileges: "WITH ALL PRIVILEGES"
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests:
+    memory: 3Gi
+    cpu: 3
+  limits:
+    memory: 2Gi
+    cpu: 3

--- a/run/helm/snap/templates/_helpers.tpl
+++ b/run/helm/snap/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Include template with its absolute path.
+The result is
+"include <abs-path-to-tpl>/<tpl-name> ."
+*/}}
+{{- define "template" -}}
+{{- $name := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $v:= $context.Template.Name | split "/" -}}
+{{- $n := len $v -}}
+{{- $last := sub $n 1 | printf "_%d" | index $v -}}
+{{- $path := $context.Template.Name | replace $last $name -}}
+{{ include $path $context }}
+{{- end -}}

--- a/run/helm/snap/templates/config/_snapteld.tpl
+++ b/run/helm/snap/templates/config/_snapteld.tpl
@@ -1,0 +1,94 @@
+#
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+# Copyright 2017 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# log_level for the snap daemon. Supported values are
+# 1 - Debug, 2 - Info, 3 - Warning, 4 - Error, 5 - Fatal.
+# Default value is 3.
+log_level: {{ .Values.config.log_level }}
+
+# Gomaxprocs sets the number of cores to use on the system
+# for snapteld to use. Default for gomaxprocs is 1
+gomaxprocs: {{ .Values.config.gomaxprocs }}
+
+# Control sections for configuration settings for the plugin
+# control module of snapteld.
+control:
+  # auto_discover_path sets a directory to auto load plugins on the start
+  # of the snap daemon
+  auto_discover_path: /opt/snap/autoload 
+
+  # cache_expiration sets the time interval for the plugin cache to use before
+  # expiring collection results from collect plugins. Default value is 500ms
+  # cache_expiration: 500ms
+
+  # max_running_plugins sets the size of the available plugin pool for each
+  # plugin loaded in the system. Default value is 3
+  # max_running_plugins: 3
+
+  # keyring_paths sets the directory(s) to search for keyring files for signed
+  # plugins. This can be a comma separated list of directories
+  # keyring_paths: /etc/snap/keyrings
+
+  # plugin_trust_level sets the plugin trust level for snapteld. The default state
+  # for plugin trust level is enabled (1). When enabled, only signed plugins that can
+  # be verified will be loaded into snapteld. Signatures are verifed from
+  # keyring files specided in keyring_path. Plugin trust can be disabled (0) which
+  # will allow loading of all plugins whether signed or not. The warning state allows
+  # for loading of signed and unsigned plugins. Warning messages will be displayed if
+  # an unsigned plugin is loaded. Any signed plugins that can not be verified will
+  # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
+  plugin_trust_level: 0
+
+  # plugins section contains plugin config settings that will be applied for
+  # plugins across tasks.
+  # plugins:
+
+# scheduler configuration settings contains all settings for scheduler
+# module
+# scheduler:
+  # work_manager_queue_size sets the size of the worker queue inside snapteld scheduler.
+  # Default value is 25.
+  # work_manager_queue_size: 25
+
+  # work_manager_pool_size sets the size of the worker pool inside snapteld scheduler.
+  # Default value is 4.
+  # work_manager_pool_size: 4
+
+# rest sections contains all the configuration items for the REST API server.
+# restapi:
+  # enable controls enabling or disabling the REST API for snapteld. Default value is enabled.
+  # enable: true
+
+  # https enables HTTPS for the REST API. If no default certificate and key are provided, then
+  # the REST API will generate a private and public key to use for communication. Default
+  # value is false
+  # https: false
+
+  # rest_auth enables authentication for the REST API. Default value is false
+  # rest_auth: false
+
+  # rest_auth_password sets the password to use for the REST API. Currently user and password
+  # combinations are not supported.
+  # rest_auth_password: changeme
+
+  # rest_certificate is the path to the certificate to use for REST API when HTTPS is also enabled.
+  # rest_certificate: /etc/snap/cert.pem
+
+  # rest_key is the path to the private key for the certificate in use by the REST API
+  # when HTTPs is enabled.
+  # rest_key: /etc/snap/cert.key
+
+  # port sets the port to start the REST API server on. Default is 8181
+# port: 8181

--- a/run/helm/snap/templates/configmap.yaml
+++ b/run/helm/snap/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config 
+  namespace: {{ .Release.Namespace }}
+data: 
+  snapteld.conf: |
+{{ tuple "config/_snapteld.tpl" . | include "template" | indent 4 }} # template _snapteld.tpl to snapteld.conf

--- a/run/helm/snap/templates/daemonset.yaml
+++ b/run/helm/snap/templates/daemonset.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: snap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  template:
+    metadata:
+      name: snap
+      labels:
+        daemon: snapteld
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: {{ .Values.privileged }}
+        ports:
+        - containerPort: 8181
+        livenessProbe:
+          httpGet:
+            path: /v1/plugins
+            port: 8181
+          initialDelaySeconds: 60
+          timeoutSeconds: 5          
+        readinessProbe:
+          httpGet:
+            path: /v1/plugins
+            port: 8181
+          initialDelaySeconds: 60
+          timeoutSeconds: 5          
+        env:
+          - name: INFLUXDB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Chart.Name }}-influxdb-auth
+                key: influxdb-user
+          - name: INFLUXDB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Chart.Name }}-influxdb-auth
+                key: influxdb-password
+          - name: NODENAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        volumeMounts:
+        - name: proc 
+          mountPath: /proc_host
+        - name: docker-sock
+          mountPath: /var/run/docker.sock
+        - name: docker-bin
+          mountPath: /usr/local/bin/docker
+        - name: docker-lib
+          mountPath: /var/lib/docker
+        - name: sys-fs
+          mountPath: /sys/fs/cgroup
+        - name: config
+          mountPath: /etc/snap
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: docker-bin
+        hostPath:
+          path: /usr/bin/docker
+      - name: docker-lib
+        hostPath:
+          path: /var/lib/docker
+      - name: sys-fs
+        hostPath:
+          path: /sys/fs/cgroup
+      - name: config
+        configMap:
+          name: {{ template "fullname" . }}-config

--- a/run/helm/snap/values.yaml
+++ b/run/helm/snap/values.yaml
@@ -1,0 +1,140 @@
+## Snap Docker image
+## ref: https://hub.docker.com/r/intelsdi/snap4kube/tags/
+##
+image:
+  repo: intelsdi/snap4kube
+  tag: monitoring
+  pullPolicy: Always
+
+## Privileged mode for Snap daemonset
+## ref: https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers
+privileged: true
+
+## Snap log level
+## ref: https://github.com/intelsdi-x/snap/blob/master/docs/SNAPTELD_CONFIGURATION.md#snapteld-configuration
+## 
+config:
+  log_level: 3
+  gomaxprocs: 1
+
+## InfluxDB configuration:
+##
+influxdb:
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: false
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    # accessMode: ReadWriteOnce
+    # size: 8Gi  
+  
+  setDefaultUser:
+    user:
+      ## The user name
+      ## Default: "admin"
+      username: "root"
+
+      ## User password
+      ## Default: Randomly generated 10 characters of Ascii
+      password: "root"
+
+      ## User privileges
+      ## Default: "WITH ALL PRIVILEGES"
+      privileges: "WITH ALL PRIVILEGES"
+                          
+## Grafana configuration:
+##
+grafana:
+  server:
+    adminUser: root 
+    adminPassword: root
+
+    imagePullPolicy: IfNotPresent
+
+    ## Set datasource in beginning
+    setDatasource:
+      ## If true, an initial Grafana Datasource will be set
+      ## Default: false
+      ##
+      enabled: true
+
+      ## How long should it take to commit failure
+      ## Default: 300
+      ##
+      activeDeadlineSeconds: 300
+
+      ## Curl Docker image
+      ## Default: appropriate/curl:latest
+      ##
+      image: appropriate/curl:latest
+
+      restartPolicy: OnFailure
+
+      ## This assembles how curl post into Grafana
+      ## Ref1: http://docs.grafana.org/reference/http_api/#create-data-source
+      ## Ref2: https://github.com/grafana/grafana/issues/1789
+      ##
+      datasource:
+        name: snap 
+        type: influxdb
+        access: proxy
+        url: "http://monitoring-influxdb:8086"
+        isDefault: true
+        database: snap
+        influxdb:
+          user: root
+          password: root
+          database: snap
+
+    ## Grafana service type
+    ##
+    serviceType: NodePort
+
+    # Persist data to a persitent volume
+    persistentVolume:
+      ## If true, Grafana will create a Persistent Volume Claim
+      ## If false, use emptyDir
+      ##
+      enabled: false
+
+      ## Grafana data Persistent Volume access modes
+      ## Must match those of existing PV or dynamic provisioner
+      ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+      ##
+      accessModes:
+        - ReadWriteOnce
+
+      ## Server data Persistent Volume annotations
+      ##
+      # annotations:
+
+      ## Grafana data Persistent Volume size
+      ## Default: 1Gi
+      ##
+      size: 1Gi
+
+      ## Data Persistent Volume Storage Class
+      ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+      ## Default: volume.alpha.kubernetes.io/storage-class: default
+      ##
+      # storageClass:
+
+    ## Alerting
+    alerting:
+      # Critical level of cpu, memory and filesystem usage
+      # per pods and nodes.
+      pods:
+        # CPU usage value in percentage, memory and filesystem in bytes
+        cpu_usage: 90
+        memory_usage: 50000000000
+        filesystem_usage: 50000000000
+      nodes:
+        # CPU usage value in percentage, memory and filesystem in bytes
+        cpu_usage: 90
+        memory_usage: 20000000000
+        filesystem_usage: 20000000000
+


### PR DESCRIPTION
PR includes:
- Grafana chart with preloaded dashboards, datasource and alerting rules
- InfluxDB chart
- Snap chart with preload plugins and tasks to monitor Kubernetes

How to test it:
`$ helm install <path-to-snap-chart> --name=snap`
`$ helm delete snap --purge`

PR yet lacks:
- README file
- NOTES.txt file