### PR TITLE
Namespace helper templates to prevent bugs

### DIFF
--- a/run/helm/snap/charts/grafana/templates/NOTES.txt
+++ b/run/helm/snap/charts/grafana/templates/NOTES.txt
@@ -1,10 +1,10 @@
 1. Get your '{{ .Values.server.adminUser }}' user password by running:
 
-   printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode);echo
+   printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode);echo
 
 2. The Grafana server can be accessed via port {{ .Values.server.httpPort }} on the following DNS name from within your cluster:
 
-   {{ template "server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+   {{ template "grafana.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{ if .Values.server.ingress.enabled }}
    From outside the cluster, the server URL(s) are:
 {{- range .Values.server.ingress.hosts }}
@@ -13,16 +13,16 @@
 {{ else }}
    Get the Grafana URL to visit by running these commands in the same shell:
 {{ if contains "NodePort" .Values.server.serviceType -}}
-     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "server.fullname" . }})
+     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.server.fullname" . }})
      export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
      echo http://$NODE_IP:$NODE_PORT
 {{ else if contains "LoadBalancer" .Values.server.serviceType -}}
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "server.fullname" . }}'
-     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafana.server.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
      echo http://$SERVICE_IP:{{ .Values.server.httpPort -}}
 {{ else if contains "ClusterIP"  .Values.server.serviceType }}
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},component={{ .Values.server.name }}" -o jsonpath="{.items[0].metadata.name}")
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.fullname" . }},component={{ .Values.server.name }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000
 {{- end }}
 {{- end }}

--- a/run/helm/snap/charts/grafana/templates/_helpers.tpl
+++ b/run/helm/snap/charts/grafana/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "grafana.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "grafana.fullname" -}}
 {{- $name := default "grafana" .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -19,11 +19,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a fully qualified server name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "server.fullname" -}}
+{{- define "grafana.server.fullname" -}}
 {{- printf "%s-%s" .Release.Name "grafana" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "template" -}}
+{{- define "grafana.template" -}}
 {{- $name := index . 0 -}}
 {{- $context := index . 1 -}}
 {{- $v:= $context.Template.Name | split "/" -}}

--- a/run/helm/snap/charts/grafana/templates/config.yaml
+++ b/run/helm/snap/charts/grafana/templates/config.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}-config
+  name: {{ template "grafana.server.fullname" . }}-config
 data:
   grafana.ini: |
     ; app_mode = production

--- a/run/helm/snap/charts/grafana/templates/deployment.yaml
+++ b/run/helm/snap/charts/grafana/templates/deployment.yaml
@@ -2,12 +2,12 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}
+  name: {{ template "grafana.server.fullname" . }}
 spec:
   replicas: 1
   template:
@@ -17,7 +17,7 @@ spec:
         {{ $key }}: {{ $value }}
       {{- end }}
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "grafana.fullname" . }}
         component: "{{ .Values.server.name }}"
         release: "{{ .Release.Name }}"
     spec:
@@ -29,12 +29,12 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "server.fullname" . }}
+                  name: {{ template "grafana.server.fullname" . }}
                   key: grafana-admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "server.fullname" . }}
+                  name: {{ template "grafana.server.fullname" . }}
                   key: grafana-admin-password
           ports:
             - containerPort: 3000
@@ -53,11 +53,11 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: {{ template "server.fullname" . }}-config
+            name: {{ template "grafana.server.fullname" . }}-config
         - name: storage-volume
       {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "server.fullname" . }}
+            claimName: {{ template "grafana.server.fullname" . }}
       {{- else }}
           emptyDir: {}
       {{- end -}}

--- a/run/helm/snap/charts/grafana/templates/ingress.yaml
+++ b/run/helm/snap/charts/grafana/templates/ingress.yaml
@@ -9,12 +9,12 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}
+  name: {{ template "grafana.server.fullname" . }}
 spec:
   rules:
   {{- range .Values.server.ingress.hosts }}

--- a/run/helm/snap/charts/grafana/templates/job.yaml
+++ b/run/helm/snap/charts/grafana/templates/job.yaml
@@ -3,27 +3,27 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}-set-datasource
+  name: {{ template "grafana.server.fullname" . }}-set-datasource
   annotations:
     pod.beta.kubernetes.io/init-containers: '[
         {
             "name": "wait-for-grafana",
             "image": "{{ .Values.server.setDatasource.initImage }}",
-            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/org; do echo waiting for myservice; sleep 5; done;"]
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/org; do echo waiting for myservice; sleep 5; done;"]
         }
     ]'
 spec:
   restartPolicy: OnFailure
   containers:
-  - name: {{ template "server.fullname" . }}-set-datasource
+  - name: {{ template "grafana.server.fullname" . }}-set-datasource
     image: "{{ .Values.server.setDatasource.image }}"
     args:
-    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
     - "-X"
     - POST
     - "-H"

--- a/run/helm/snap/charts/grafana/templates/job_cluster.yaml
+++ b/run/helm/snap/charts/grafana/templates/job_cluster.yaml
@@ -2,32 +2,32 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}-import-dash-cluster
+  name: {{ template "grafana.server.fullname" . }}-import-dash-cluster
   annotations:
     pod.beta.kubernetes.io/init-containers: '[
         {
             "name": "wait-for-db",
             "image": "{{ .Values.server.setDatasource.initImage }}",
-            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
         }
     ]'
 spec:
   restartPolicy: OnFailure
   containers:
-  - name: {{ template "server.fullname" . }}-import-dash-cluster
+  - name: {{ template "grafana.server.fullname" . }}-import-dash-cluster
     image: "{{ .Values.server.setDatasource.image }}"
     args:
-    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
     - "-X"
     - POST
     - "-H"
     - "Content-Type: application/json;charset=UTF-8"
     - "--data-binary"
     - |
-{{ tuple "dashboards/_cluster.json.tpl" . | include "template" | indent 6 }}
+{{ tuple "dashboards/_cluster.json.tpl" . | include "grafana.template" | indent 6 }}
 

--- a/run/helm/snap/charts/grafana/templates/job_pods.yaml
+++ b/run/helm/snap/charts/grafana/templates/job_pods.yaml
@@ -2,32 +2,32 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}-import-dash-pods
+  name: {{ template "grafana.server.fullname" . }}-import-dash-pods
   annotations:
     pod.beta.kubernetes.io/init-containers: '[
         {
             "name": "wait-for-db",
             "image": "{{ .Values.server.setDatasource.initImage }}",
-            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
+            "command": ["sh", "-c", "until curl --fail http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources/name/snap; do echo waiting for myservice; sleep 5; done;"]
         }
     ]'
 spec:
   restartPolicy: OnFailure
   containers:
-  - name: {{ template "server.fullname" . }}-import-dash-pods
+  - name: {{ template "grafana.server.fullname" . }}-import-dash-pods
     image: "{{ .Values.server.setDatasource.image }}"
     args:
-    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
+    - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/dashboards/db"
     - "-X"
     - POST
     - "-H"
     - "Content-Type: application/json;charset=UTF-8"
     - "--data-binary"
     - |
-{{ tuple "dashboards/_pods.json.tpl" . | include "template" | indent 6 }}
+{{ tuple "dashboards/_pods.json.tpl" . | include "grafana.template" | indent 6 }}
 

--- a/run/helm/snap/charts/grafana/templates/pvc.yaml
+++ b/run/helm/snap/charts/grafana/templates/pvc.yaml
@@ -12,12 +12,12 @@ metadata:
     {{ $key }}: {{ $value }}
   {{- end }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}
+  name: {{ template "grafana.server.fullname" . }}
 spec:
   accessModes:
 {{- range .Values.server.persistentVolume.accessModes }}

--- a/run/helm/snap/charts/grafana/templates/secret.yaml
+++ b/run/helm/snap/charts/grafana/templates/secret.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}
+  name: {{ template "grafana.server.fullname" . }}
 data:
   {{ if .Values.server.adminPassword }}
   grafana-admin-password:  {{ .Values.server.adminPassword | b64enc | quote }}

--- a/run/helm/snap/charts/grafana/templates/svc.yaml
+++ b/run/helm/snap/charts/grafana/templates/svc.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}
+  name: {{ template "grafana.server.fullname" . }}
 spec:
   ports:
     - name: {{ default "http" .Values.server.httpPortName | quote }}
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
       targetPort: 3000
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "grafana.fullname" . }}
     component: "{{ .Values.server.name }}"
   type: "{{ .Values.server.serviceType }}"
 {{- if contains "LoadBalancer" .Values.server.serviceType }}

--- a/run/helm/snap/charts/influxdb/templates/_helpers.tpl
+++ b/run/helm/snap/charts/influxdb/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "influxdb.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "influxdb.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/run/helm/snap/charts/influxdb/templates/config.yaml
+++ b/run/helm/snap/charts/influxdb/templates/config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: influxdb-config
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/run/helm/snap/charts/influxdb/templates/deployment.yaml
+++ b/run/helm/snap/charts/influxdb/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "influxdb.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "influxdb.fullname" . }}
         heritage: {{ .Release.Service | quote }}
     spec:
       containers:
@@ -43,7 +43,7 @@ spec:
       - name: influxdb-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}-pvc
+          claimName: {{ template "influxdb.fullname" . }}-pvc
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/run/helm/snap/charts/influxdb/templates/post-deploy.yaml
+++ b/run/helm/snap/charts/influxdb/templates/post-deploy.yaml
@@ -3,11 +3,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  name: {{ template "fullname" . }}-create-user-{{ randAlphaNum 5 | lower }}
+  name: {{ template "influxdb.fullname" . }}-create-user-{{ randAlphaNum 5 | lower }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
 spec:
@@ -15,22 +15,22 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "influxdb.fullname" . }}
         release: {{ .Release.Name | quote }}
     spec:
       containers:
-      - name: {{ template "fullname" . }}-create-user
+      - name: {{ template "influxdb.fullname" . }}-create-user
         image: {{ .Values.setDefaultUser.image | quote }}
         env:
           - name: INFLUXDB_USER
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" . }}-auth
+                name: {{ template "influxdb.fullname" . }}-auth
                 key: influxdb-user
           - name: INFLUXDB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" . }}-auth
+                name: {{ template "influxdb.fullname" . }}-auth
                 key: influxdb-password
         args:
           - "/bin/sh"

--- a/run/helm/snap/charts/influxdb/templates/pvc.yaml
+++ b/run/helm/snap/charts/influxdb/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}-pvc
+  name: {{ template "influxdb.fullname" . }}-pvc
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/run/helm/snap/charts/influxdb/templates/secret.yaml
+++ b/run/helm/snap/charts/influxdb/templates/secret.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-  name: {{ template "fullname" . }}-auth
+  name: {{ template "influxdb.fullname" . }}-auth
 data:
   {{- if .Values.setDefaultUser.user.password }}
   influxdb-password:  {{ .Values.setDefaultUser.user.password | b64enc | quote }}

--- a/run/helm/snap/charts/influxdb/templates/service.yaml
+++ b/run/helm/snap/charts/influxdb/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: monitoring-influxdb
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,4 +13,4 @@ spec:
     port: {{ .Values.port_number }}
     targetPort: {{ .Values.port_number }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}

--- a/run/helm/snap/templates/daemonset.yaml
+++ b/run/helm/snap/templates/daemonset.yaml
@@ -25,23 +25,23 @@ spec:
             path: /v1/plugins
             port: 8181
           initialDelaySeconds: 60
-          timeoutSeconds: 5          
+          timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /v1/plugins
             port: 8181
           initialDelaySeconds: 60
-          timeoutSeconds: 5          
+          timeoutSeconds: 5
         env:
           - name: INFLUXDB_USER
             valueFrom:
               secretKeyRef:
-                name: {{ .Chart.Name }}-influxdb-auth
+                name: {{ .Release.Name }}-influxdb-auth
                 key: influxdb-user
           - name: INFLUXDB_PASS
             valueFrom:
               secretKeyRef:
-                name: {{ .Chart.Name }}-influxdb-auth
+                name: {{ .Release.Name }}-influxdb-auth
                 key: influxdb-password
           - name: NODENAME
             valueFrom:


### PR DESCRIPTION
Templates can be shared between charts. This makes it so that subcharts
have specific templates and don't potentially use each others names. Also made secret influxdb secret use release name instead of chart name.